### PR TITLE
[#19] 재사용 가능한 Action Modal 구현

### DIFF
--- a/src/@types/modal.ts
+++ b/src/@types/modal.ts
@@ -14,4 +14,12 @@ export type ModalContentProps<T = unknown> = {
     onAbort: (error?: Error) => void; // catch
 };
 
-export type ModalStyle = 'global' | 'local';
+export type AlertModalProps = {
+    alertType: AlertModalType;
+    desc: string;
+    onSubmit?: (result: boolean) => void; // then
+    onAbort?: (error?: Error) => void; // catch
+};
+
+export type ModalStyle = 'global' | 'local' | 'alert';
+export type AlertModalType = 'confirm' | 'delete';

--- a/src/components/@common/Button/Button.module.css
+++ b/src/components/@common/Button/Button.module.css
@@ -14,3 +14,13 @@ button.default {
     background: #e9e9e9;
     color: #252525;
 }
+
+button.confirm {
+    background: #cbecc6;
+    color: #199a06;
+}
+
+button.delete {
+    background: #ffd7d7;
+    color: #ff5a5a;
+}

--- a/src/components/@common/Modal/ModalContents/Alert/AlertModal.module.css
+++ b/src/components/@common/Modal/ModalContents/Alert/AlertModal.module.css
@@ -1,0 +1,7 @@
+.desc {
+    text-align: center;
+    margin-bottom: 48px;
+    padding: 0 12px;
+    line-height: 1.5em;
+    font-size: 1.2rem;
+}

--- a/src/components/@common/Modal/ModalContents/Alert/AlertModal.tsx
+++ b/src/components/@common/Modal/ModalContents/Alert/AlertModal.tsx
@@ -1,0 +1,32 @@
+import Button from '@components/@common/Button/Button';
+import ModalButtonGroup from '@components/@common/Modal/ModalTemplate/ModalButtonGroup';
+import ModalContent from '@components/@common/Modal/ModalTemplate/ModalContent';
+import ModalHeader from '@components/@common/Modal/ModalTemplate/ModalHeader';
+import ModalTemplate from '@components/@common/Modal/ModalTemplate/ModalTemplate';
+import classnames from 'classnames/bind';
+import { AlertModalProps } from 'src/@types/modal';
+import styles from './AlertModal.module.css';
+const cx = classnames.bind(styles);
+
+const displayName = {
+    confirm: '확인',
+    delete: '삭제',
+};
+
+const AlertModal = ({ alertType, desc, onSubmit, onAbort }: AlertModalProps) => {
+    const handleClick = () => onSubmit?.(true);
+    return (
+        <ModalTemplate isOverlay={true} styleType="alert" transparent={true}>
+            <ModalHeader onClose={onAbort} />
+            <ModalContent>
+                <p className={cx('desc')}>{desc}</p>
+                <ModalButtonGroup>
+                    <Button text="취소" variant="default" onClick={onAbort} />
+                    <Button text={displayName[alertType]} variant={alertType} type="submit" onClick={handleClick} />
+                </ModalButtonGroup>
+            </ModalContent>
+        </ModalTemplate>
+    );
+};
+
+export default AlertModal;

--- a/src/components/@common/Modal/ModalTemplate/ModalHeader.tsx
+++ b/src/components/@common/Modal/ModalTemplate/ModalHeader.tsx
@@ -4,7 +4,7 @@ import { IoIosClose } from 'react-icons/io';
 import styles from './ModalTemplate.module.css';
 const cx = classnames.bind(styles);
 
-const ModalHeader = ({ title, onClose }: { title: string; onClose?: () => void }) => {
+const ModalHeader = ({ title = '', onClose }: { title?: string; onClose?: () => void }) => {
     return (
         <header className={cx('modal-header')}>
             <h1 className={cx('title')}>{title}</h1>

--- a/src/components/@common/Modal/ModalTemplate/ModalTemplate.module.css
+++ b/src/components/@common/Modal/ModalTemplate/ModalTemplate.module.css
@@ -5,6 +5,8 @@
     padding: 28px;
     border-radius: 16px;
     position: relative;
+    -webkit-box-shadow: -5px 10px 49px 0px rgba(36, 36, 36, 0.25);
+    box-shadow: -5px 10px 49px 0px rgba(36, 36, 36, 0.25);
 }
 
 .modal-container.local {

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,6 +1,7 @@
 import Modal from '@components/@common/Modal/Modal';
 import ModalPortal from '@components/@common/Modal/ModalPortal';
 import { ComponentType, createElement, useCallback, useContext, useEffect, useId } from 'react';
+import { AlertModalProps } from 'src/@types/modal';
 import { modalContext } from 'src/context/ModalContext';
 import { assert } from 'src/utils/assert';
 
@@ -31,6 +32,26 @@ export const useModal = () => {
         [modalId, open, closeModal],
     );
 
+    const openAlertModal = useCallback(
+        <P extends AlertModalProps>(component: ComponentType<P>, props: P) =>
+            new Promise((resolve, reject) => {
+                const modal = {
+                    element: createElement(component, { ...props }),
+                    modalId,
+                    resolve: <T extends {}>(value?: T) => {
+                        resolve(value);
+                        closeModal();
+                    },
+                    reject: (reason?: Error) => {
+                        reject(reason);
+                        closeModal();
+                    },
+                };
+                open(modal);
+            }),
+        [modalId, open, closeModal],
+    );
+
     const renderModal = useCallback(() => {
         const modal = modals.find((modal) => modal.modalId === modalId);
         return (
@@ -44,5 +65,5 @@ export const useModal = () => {
 
     useEffect(() => closeModal, [closeModal]);
 
-    return { openModal, closeModal, renderModal };
+    return { openModal, openAlertModal, closeModal, renderModal };
 };


### PR DESCRIPTION
## PR 타입
- [X] 기능 추가

## 작업 내용
1. AlertModal 작성 및 관련 Type 추가
   - alertType / desc 속성 추가
   - onSubmit / onAbort 옵셔널 적용
2. 공통 Button UI Type 추가
3. useModal - openAlertModal 함수 추가

## 설명
등록/수정/삭제처럼 동일한 템플릿에 버튼과 내용만 달라지는 모달을 구현하는데 
`1. AlertModal 컴포넌트 1개로 재사용`과 
`2. Type별 컴포넌트를 생성한 뒤 기존 로직을 재사용`하는 방법 중 고민
- 1번: desc이 자주 변경될 수 있다.
- 2번: 지정된 양식 외에 변경될 일이 많이 없다.

현재까지는 다른 양식의 Alert가 필요하지 않지만, 자유도를 더 주기 위한 방법으로 1번을 우선으로 택함

## 관련 이슈
close #19 